### PR TITLE
Increase precedence of len

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -301,7 +301,7 @@ module.exports = grammar({
 
     unary_op: $ => prec(5, seq(choice("-", "!", "~", "*"), $.expression)),
 
-    len: $ => seq("|", $.expression, "|"),
+    len: $ => prec(10, seq("|", $.expression, "|")),
 
     if: $ =>
       prec.left(


### PR DESCRIPTION
Currently, `print |x| + 4` is parsed as `(len (binary_op lhs rhs))` instead of `(binary_op (len) rhs)`, making it difficult to format `|x| + 1` correctly using spicy-format.

    entities: (statement [3, 0] - [3, 10]
      (expression [3, 0] - [3, 9]
        (len [3, 0] - [3, 9]
          (expression [3, 2] - [3, 9]
            (binary_op [3, 2] - [3, 9]
              lhs: (expression [3, 2] - [3, 3]
                (ident [3, 2] - [3, 3]))
              rhs: (expression [3, 6] - [3, 9]
                (unary_op [3, 6] - [3, 9]

Not sure this is the right fix, but the tree-sitter parse output looks better afterwards.