### PR TITLE
Parsing parsing of field to sink forwarding

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -219,7 +219,7 @@ module.exports = grammar({
             "conditional",
             optional(prec(2000, seq("if", "(", $.expression, ")"))),
           ),
-          optional(prec.left(seq("->", $.sink))),
+          optional(prec.left(seq("->", field("sink", $.expression)))),
           choice(
             seq(
               seq(optional($.is_debug), optional($.foreach)),
@@ -230,7 +230,6 @@ module.exports = grammar({
         ),
       ),
 
-    sink: $ => seq(optional(seq($.self_id, ".")), $.ident),
     sink_decl: $ => seq("sink", $.ident, ";"),
 
     optional: _ => "&optional",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1472,8 +1472,12 @@
                       "value": "->"
                     },
                     {
-                      "type": "SYMBOL",
-                      "name": "sink"
+                      "type": "FIELD",
+                      "name": "sink",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      }
                     }
                   ]
                 }
@@ -1557,36 +1561,6 @@
           }
         ]
       }
-    },
-    "sink": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "self_id"
-                },
-                {
-                  "type": "STRING",
-                  "value": "."
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ident"
-        }
-      ]
     },
     "sink_decl": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -563,6 +563,16 @@
           }
         ]
       },
+      "sink": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
       "skip": {
         "multiple": false,
         "required": false,
@@ -644,10 +654,6 @@
         },
         {
           "type": "is_debug",
-          "named": true
-        },
-        {
-          "type": "sink",
           "named": true
         }
       ]
@@ -1350,25 +1356,6 @@
         },
         {
           "type": "ident",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "sink",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "ident",
-          "named": true
-        },
-        {
-          "type": "self_id",
           "named": true
         }
       ]

--- a/test/corpus/types/unit.spicy
+++ b/test/corpus/types/unit.spicy
@@ -162,10 +162,13 @@ type Main = unit {
           (name)))
       (attribute
         (attribute_name))
-      (sink
-        (self_id)
-        (ident
-          (name))))
+      (expression
+        (type_member
+          (expression
+            (self_id))
+          (type_member_ident
+            (ident
+              (name))))))
     (sink_decl
       (ident
         (name)))))
@@ -174,8 +177,9 @@ type Main = unit {
 Sink external
 ================================================================================
 
-type Main = unit(s: sink&) {
+type Main = unit(s: sink&, other: Unit) {
     : bytes &eod -> s;
+    : bytes &eod -> other.s;
 };
 
 --------------------------------------------------------------------------------
@@ -189,6 +193,11 @@ type Main = unit(s: sink&) {
         (name))
       (typename
         (ident
+          (name)))
+      (ident
+        (name))
+      (typename
+        (ident
           (name))))
     (field_decl
       (typename
@@ -196,9 +205,23 @@ type Main = unit(s: sink&) {
           (name)))
       (attribute
         (attribute_name))
-      (sink
+      (expression
         (ident
-          (name))))))
+          (name))))
+    (field_decl
+      (typename
+        (ident
+          (name)))
+      (attribute
+        (attribute_name))
+      (expression
+        (type_member
+          (expression
+            (ident
+              (name)))
+          (type_member_ident
+            (ident
+              (name))))))))
 
 ================================================================================
 Hook decl


### PR DESCRIPTION
This was previously too restrictive and did not parse all constructs supported by Spicy. We now are very general.