### PR TITLE
Add proper parsing of parameterized types

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -440,24 +440,23 @@ module.exports = grammar({
       prec(
         4000,
         choice(
-          seq(
-            $.ident,
-            repeat(
-              seq(
-                "<",
-                commaSep1(
-                  seq(
-                    optional(field("name", seq($.ident, ":"))),
-                    field("type_", $.typename),
-                  ),
-                ),
-                ">",
-              ),
-            ),
-            repeat(choice("&", "[]")),
-          ),
+          seq(choice($.ident, $.parameterized_type), repeat(choice("&", "[]"))),
           $.bitfield,
         ),
+      ),
+
+    parameterized_type: $ =>
+      seq(
+        choice("vector", "set", "optional", "result", "tuple"),
+        "<",
+        commaSep1(
+          seq(
+            // Allow for named fields in tuples.
+            optional(field("name", seq($.ident, ":"))),
+            field("type_", $.typename),
+          ),
+        ),
+        ">",
       ),
 
     cast: $ => seq("cast", "<", $.ident, ">", "(", $.expression, ")"),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2756,117 +2756,17 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "ident"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "<"
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "FIELD",
-                                  "name": "name",
-                                  "content": {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "SYMBOL",
-                                        "name": "ident"
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": ":"
-                                      }
-                                    ]
-                                  }
-                                },
-                                {
-                                  "type": "BLANK"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "FIELD",
-                              "name": "type_",
-                              "content": {
-                                "type": "SYMBOL",
-                                "name": "typename"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": ","
-                              },
-                              {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "FIELD",
-                                        "name": "name",
-                                        "content": {
-                                          "type": "SEQ",
-                                          "members": [
-                                            {
-                                              "type": "SYMBOL",
-                                              "name": "ident"
-                                            },
-                                            {
-                                              "type": "STRING",
-                                              "value": ":"
-                                            }
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "type": "BLANK"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "FIELD",
-                                    "name": "type_",
-                                    "content": {
-                                      "type": "SYMBOL",
-                                      "name": "typename"
-                                    }
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "STRING",
-                      "value": ">"
-                    }
-                  ]
-                }
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "ident"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "parameterized_type"
+                  }
+                ]
               },
               {
                 "type": "REPEAT",
@@ -2892,6 +2792,137 @@
           }
         ]
       }
+    },
+    "parameterized_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "vector"
+            },
+            {
+              "type": "STRING",
+              "value": "set"
+            },
+            {
+              "type": "STRING",
+              "value": "optional"
+            },
+            {
+              "type": "STRING",
+              "value": "result"
+            },
+            {
+              "type": "STRING",
+              "value": "tuple"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "FIELD",
+                      "name": "name",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "ident"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": ":"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "FIELD",
+                  "name": "type_",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "typename"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "FIELD",
+                            "name": "name",
+                            "content": {
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "ident"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": ":"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "type_",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "typename"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
     },
     "cast": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1146,6 +1146,36 @@
     }
   },
   {
+    "type": "parameterized_type",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ":",
+            "named": false
+          },
+          {
+            "type": "ident",
+            "named": true
+          }
+        ]
+      },
+      "type_": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "typename",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "params",
     "named": true,
     "fields": {},
@@ -1730,32 +1760,7 @@
   {
     "type": "typename",
     "named": true,
-    "fields": {
-      "name": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": ":",
-            "named": false
-          },
-          {
-            "type": "ident",
-            "named": true
-          }
-        ]
-      },
-      "type_": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "typename",
-            "named": true
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
       "multiple": false,
       "required": true,
@@ -1766,6 +1771,10 @@
         },
         {
           "type": "ident",
+          "named": true
+        },
+        {
+          "type": "parameterized_type",
           "named": true
         }
       ]
@@ -2301,6 +2310,10 @@
     "named": true
   },
   {
+    "type": "optional",
+    "named": false
+  },
+  {
     "type": "port",
     "named": true
   },
@@ -2321,12 +2334,20 @@
     "named": true
   },
   {
+    "type": "result",
+    "named": false
+  },
+  {
     "type": "return",
     "named": false
   },
   {
     "type": "self_id",
     "named": true
+  },
+  {
+    "type": "set",
+    "named": false
   },
   {
     "type": "sink",
@@ -2353,6 +2374,10 @@
     "named": false
   },
   {
+    "type": "tuple",
+    "named": false
+  },
+  {
     "type": "type",
     "named": false
   },
@@ -2366,6 +2391,10 @@
   },
   {
     "type": "var",
+    "named": false
+  },
+  {
+    "type": "vector",
     "named": false
   },
   {

--- a/test/corpus/type.spicy
+++ b/test/corpus/type.spicy
@@ -13,14 +13,13 @@ type X = bitfield(8) {
     (ident
       (name))
     (typename
-      (ident
-        (name))
-      (typename
-        (ident
-          (name)))
-      (typename
-        (ident
-          (name)))))
+      (parameterized_type
+        (typename
+          (ident
+            (name)))
+        (typename
+          (ident
+            (name))))))
   (type_decl
     (ident
       (name))
@@ -132,21 +131,20 @@ global tu: tuple<a: int32, string, c: bool> = (1, "2", True);
     (ident
       (name))
     (typename
-      (ident
-        (name))
-      (ident
-        (name))
-      (typename
+      (parameterized_type
         (ident
-          (name)))
-      (typename
+          (name))
+        (typename
+          (ident
+            (name)))
+        (typename
+          (ident
+            (name)))
         (ident
-          (name)))
-      (ident
-        (name))
-      (typename
-        (ident
-          (name))))
+          (name))
+        (typename
+          (ident
+            (name)))))
     (expression
       (tuple
         (expression
@@ -155,3 +153,80 @@ global tu: tuple<a: int32, string, c: bool> = (1, "2", True);
           (string))
         (expression
           (boolean))))))
+
+====
+Hardcoded parameterized types
+====
+global xs: vector<uint64>;
+global xs: set<uint64>;
+global xs: optional<uint64>;
+global xs: result<uint64>;
+global xs: tuple<uint64, string>;
+global xs: tuple<a: uint64, b: string>;
+----
+
+(module
+  (var_decl
+    (linkage)
+    (ident
+      (name))
+    (typename
+      (parameterized_type
+        (typename
+          (ident
+            (name))))))
+  (var_decl
+    (linkage)
+    (ident
+      (name))
+    (typename
+      (parameterized_type
+        (typename
+          (ident
+            (name))))))
+  (var_decl
+    (linkage)
+    (ident
+      (name))
+    (typename
+      (parameterized_type
+        (typename
+          (ident
+            (name))))))
+  (var_decl
+    (linkage)
+    (ident
+      (name))
+    (typename
+      (parameterized_type
+        (typename
+          (ident
+            (name))))))
+  (var_decl
+    (linkage)
+    (ident
+      (name))
+    (typename
+      (parameterized_type
+        (typename
+          (ident
+            (name)))
+        (typename
+          (ident
+            (name))))))
+  (var_decl
+    (linkage)
+    (ident
+      (name))
+    (typename
+      (parameterized_type
+        (ident
+          (name))
+        (typename
+          (ident
+            (name)))
+        (ident
+          (name))
+        (typename
+          (ident
+            (name)))))))


### PR DESCRIPTION
When parsing a parameterized type like `vector<uint64>` parsing could become ambiguous (is this an expression with comparison operators `<`/`>` or a type?). This meant that in certain places parameterized types were not parsed correctly.

This patch fixes this by simply hardcoding all types which can be parameterized.