### PR TITLE
Add support for parsing nested unit switch with lahead

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -175,6 +175,7 @@ module.exports = grammar({
           "->",
           choice(
             $.field_decl,
+            $.unit_switch,
             seq("{", choice(repeat($.field_decl), $.unit_switch), "}"),
           ),
         ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1084,6 +1084,10 @@
                 "name": "field_decl"
               },
               {
+                "type": "SYMBOL",
+                "name": "unit_switch"
+              },
+              {
                 "type": "SEQ",
                 "members": [
                   {

--- a/test/corpus/types/unit.spicy
+++ b/test/corpus/types/unit.spicy
@@ -885,6 +885,17 @@ type X = unit {
   };
 };
 
+# Nested unit switch with lahead.
+type test5 = unit {
+    switch {
+        -> switch {
+            -> a: b"a";
+            -> b: b"b";
+        };
+        -> c: b"c";
+    };
+};
+
 --------------------------------------------------------------------------------
 
 (module
@@ -904,7 +915,29 @@ type X = unit {
                 (name))
               (typename
                 (ident
-                  (name))))))))))
+                  (name)))))))))
+  (comment)
+  (type_decl
+    (ident
+      (name))
+    (unit_switch
+      (unit_switch_case
+        (unit_switch
+          (unit_switch_case
+            (field_decl
+              (ident
+                (name))
+              (bytes)))
+          (unit_switch_case
+            (field_decl
+              (ident
+                (name))
+              (bytes)))))
+      (unit_switch_case
+        (field_decl
+          (ident
+            (name))
+          (bytes))))))
 
 ================================================================================
 Field types w/ parse attributes


### PR DESCRIPTION
This adds support for parsing unit switch with lahead, zeek/spicy#1810.