### PR TITLE
Let users pick the version of the tree-sitter dep they want

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,13 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.22.6"
+# Do not pull in specific tree-sitter version so consumers can pick on which
+# fits their requirements. The generated sources should be built with the
+# version pinned in `package.json`; the Rust tests are expected to use the
+# latest version.
+tree-sitter = "*"
 
 [build-dependencies]
 cc = "1.0.87"
+
+[workspace]

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -7,7 +7,7 @@
 //! let code = r#"
 //! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_spicy::language()).expect("Error loading Spicy grammar");
+//! parser.set_language(&tree_sitter_spicy::language()).expect("Error loading Spicy grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! assert!(!tree.root_node().has_error());
 //! ```
@@ -48,7 +48,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
+            .set_language(&super::language())
             .expect("Error loading Spicy grammar");
     }
 }


### PR DESCRIPTION
Many crates consuming tree-sitter grammars either only work with older
or newer versions. Pinning an explicit version made it impossible to use
this grammar with different tools, so removing any pinning.