### PR TITLE
Allow any expression for enum label values

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -108,7 +108,7 @@ module.exports = grammar({
         ";",
       ),
 
-    enum_label: $ => seq(field("name", $.ident), optional(seq("=", $.integer))),
+    enum_label: $ => seq(field("name", $.ident), optional(seq("=", $.expression))),
 
     struct_decl: $ =>
       seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -613,7 +613,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "integer"
+                  "name": "expression"
                 }
               ]
             },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -340,7 +340,7 @@
       "required": false,
       "types": [
         {
-          "type": "integer",
+          "type": "expression",
           "named": true
         }
       ]
@@ -1110,6 +1110,7 @@
   {
     "type": "module",
     "named": true,
+    "root": true,
     "fields": {
       "entities": {
         "multiple": true,
@@ -2535,11 +2536,11 @@
   },
   {
     "type": "optional",
-    "named": true
+    "named": false
   },
   {
     "type": "optional",
-    "named": false
+    "named": true
   },
   {
     "type": "port",

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/test/corpus/types/enum
+++ b/test/corpus/types/enum
@@ -14,6 +14,11 @@ public type E = enum {
     B,
 };
 
+public type E = enum {
+    A = '1',
+    B = '2',
+};
+
 --------------------------------------------------------------------------------
 
 (module
@@ -38,7 +43,22 @@ public type E = enum {
     (enum_label
       (ident
         (name))
-      (integer))
+      (expression
+        (integer)))
     (enum_label
       (ident
-        (name)))))
+        (name))))
+  (enum_decl
+    (visibility)
+    (ident
+      (name))
+    (enum_label
+      (ident
+        (name))
+      (expression
+        (char)))
+    (enum_label
+      (ident
+        (name))
+      (expression
+        (char)))))


### PR DESCRIPTION
This was messing up my spicy enum when formatting. It looks like:

```
type E = enum {
    A = '1',
    B = '2',
    C = '3',
    D = '4',
    E = '5',
    F = '6',
};
```

Just allowing any expression on the RHS of the equals seems right to me

Apologies if the generated files are a little off (like the `alloc.h`) - feel free to take a look at how that reacts locally