### PR TITLE
Fix parsing of struct fields

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -122,10 +122,13 @@ module.exports = grammar({
         "=",
         "struct",
         "{",
-        repeat($.field_decl),
+        repeat(alias($._struct_field, $.field_decl)),
         "}",
         ";",
       ),
+
+    _struct_field: $ =>
+      seq(field("name", $.ident), ":", $.typename, optional($.attribute), ";"),
 
     library_type: $ => seq("__library_type", "(", $.string, ")"),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -676,13 +676,55 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "field_decl"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_struct_field"
+            },
+            "named": true,
+            "value": "field_decl"
           }
         },
         {
           "type": "STRING",
           "value": "}"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "_struct_field": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ident"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "typename"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "attribute"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -608,7 +608,7 @@
       },
       "type_": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "array_access",
@@ -668,6 +668,10 @@
       "required": false,
       "types": [
         {
+          "type": "attribute",
+          "named": true
+        },
+        {
           "type": "block",
           "named": true
         },
@@ -677,6 +681,10 @@
         },
         {
           "type": "is_debug",
+          "named": true
+        },
+        {
+          "type": "typename",
           "named": true
         }
       ]

--- a/test/corpus/types/struct
+++ b/test/corpus/types/struct
@@ -4,6 +4,7 @@ Struct
 
 type S = struct {};
 type S = struct { a: uint8; s: S &foo; };
+type S = struct { not_a_parseable_type: vector<uint8>; };
 
 --------------------------------------------------------------------------------
 
@@ -27,4 +28,15 @@ type S = struct { a: uint8; s: S &foo; };
         (ident
           (name)))
       (attribute
-        (attribute_name)))))
+        (attribute_name))))
+  (struct_decl
+    (ident
+      (name))
+    (field_decl
+      (ident
+        (name))
+      (typename
+        (parameterized_type
+          (typename
+            (ident
+              (name))))))))


### PR DESCRIPTION
Fields in structs are not constrained to parseable types.