### PR TITLE
Fix parsing of set `add`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -544,7 +544,7 @@ module.exports = grammar({
 
     new: $ => prec.right(seq("new", $.expression)),
 
-    set_add: $ => seq("add", $.ident, "[", $.expression, "]"),
+    set_add: $ => seq("add", $.array_access),
 
     list_comp: $ =>
       seq("[", $.expression, "for", $.ident, "in", $.expression, "]"),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3369,19 +3369,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "ident"
-        },
-        {
-          "type": "STRING",
-          "value": "["
-        },
-        {
-          "type": "SYMBOL",
-          "name": "expression"
-        },
-        {
-          "type": "STRING",
-          "value": "]"
+          "name": "array_access"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1558,15 +1558,11 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
-          "type": "expression",
-          "named": true
-        },
-        {
-          "type": "ident",
+          "type": "array_access",
           "named": true
         }
       ]

--- a/test/corpus/statement.spicy
+++ b/test/corpus/statement.spicy
@@ -45,6 +45,7 @@ Set add
 
 add s1[12];
 add s2[s3];
+add foo.s3[1];
 
 --------------------------------------------------------------------------------
 
@@ -52,18 +53,36 @@ add s2[s3];
   (statement
     (expression
       (set_add
-        (ident
-          (name))
-        (expression
-          (integer)))))
+        (array_access
+          (expression
+            (ident
+              (name)))
+          (expression
+            (integer))))))
   (statement
     (expression
       (set_add
-        (ident
-          (name))
-        (expression
-          (ident
-            (name)))))))
+        (array_access
+          (expression
+            (ident
+              (name)))
+          (expression
+            (ident
+              (name)))))))
+  (statement
+    (expression
+      (set_add
+        (array_access
+          (expression
+            (type_member
+              (expression
+                (ident
+                  (name)))
+              (type_member_ident
+                (ident
+                  (name)))))
+          (expression
+            (integer)))))))
 
 ================================================================================
 Local variable
@@ -104,6 +123,7 @@ Delete
 ===
 
 delete xs[x];
+delete foo.xs[x];
 
 ---
 
@@ -114,6 +134,20 @@ delete xs[x];
         (expression
           (ident
             (name)))
+        (expression
+          (ident
+            (name))))))
+  (statement
+    (delete
+      (array_access
+        (expression
+          (type_member
+            (expression
+              (ident
+                (name)))
+            (type_member_ident
+              (ident
+                (name)))))
         (expression
           (ident
             (name)))))))


### PR DESCRIPTION
We would previously miss `add` on sets which were not simple variables, e.g., record fields.